### PR TITLE
Replace Muli with Mulish

### DIFF
--- a/typography/readme.md
+++ b/typography/readme.md
@@ -6,7 +6,7 @@
 
 The Foundation For Public Code uses the Mulish font for headings and the logo. Mulish is licenced with the Open Font License
 
-* [Mulish on Google Fonts](https://fonts.google.com/specimen/Mulish?query=muli)
+* [Mulish on Google Fonts](https://fonts.google.com/specimen/Mulish)
 * [GitHub repository for the Mulish Font](https://github.com/googlefonts/mulish)
 
 ## Body text: system native

--- a/typography/readme.md
+++ b/typography/readme.md
@@ -1,13 +1,13 @@
 # Typography
 
-## Headings and logo: Muli
+## Headings and logo: Mulish
 
 ![Logo](../logo/mark-and-name-over-two-lines.svg)
 
-The Foundation For Public Code uses the Muli font for headings and the logo. Muli is licenced with the Open Font License
+The Foundation For Public Code uses the Mulish font for headings and the logo. Mulish is licenced with the Open Font License
 
-* [Muli on Google Fonts](https://fonts.google.com/specimen/Muli)
-* [GitHub repository for the Muli Font](https://github.com/vernnobile/MuliFont)
+* [Mulish on Google Fonts](https://fonts.google.com/specimen/Mulish?query=muli)
+* [GitHub repository for the Mulish Font](https://github.com/googlefonts/mulish)
 
 ## Body text: system native
 


### PR DESCRIPTION
With the passing of Vernon Adams, this font is now updated and maintained by the Google Fonts team and @Fonthausen and @m4rc1e.

This pull request renames and redirects to the new sites and repositories.

-----
[View rendered typography/readme.md](https://github.com/publiccodenet/brand/blob/update-mulish/typography/readme.md)