### PR TITLE
update copyright year to 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ The visual identity of the Foundation for Public Code is meant to be institution
 
 ## License
 
-© Foundation for Public Code, 2018
+© Foundation for Public Code, 2021


### PR DESCRIPTION
It's not 2018 anymore. This will also nudge the repo to pull in new changes to the footer ([Jekyll theme PR 68](https://github.com/publiccodenet/jekyll-theme/pull/68).

-----
[View rendered README.md](https://github.com/publiccodenet/brand/blob/update-copyright-year/README.md)